### PR TITLE
package version and setup.py version from same location

### DIFF
--- a/chardet/__init__.py
+++ b/chardet/__init__.py
@@ -15,7 +15,7 @@
 # 02110-1301  USA
 ######################### END LICENSE BLOCK #########################
 
-__version__ = "1.0.1"
+__version__ = "1.0.3"
 
 def detect(aBuf):
     import universaldetector

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,11 @@ if not hasattr(DistributionMetadata, 'classifiers'):
 if not hasattr(DistributionMetadata, 'download_url'):
     DistributionMetadata.download_url = None
 
+import chardet
+
 setup(
     name = 'chardet',
-    version = '1.0.3',
+    version = chardet.__version__,
     description = 'Universal encoding detector',
     long_description = """\
 Universal character encoding detector


### PR DESCRIPTION
@dcramer, I had a bug I needed to work on and while it turns out I solved it another way. I forked your repo, thanks for putting it up. Easiest place to get the source.

I noticed the version number in setup.py was different than the one the package. This patch shows how I like to use the package.**version** in the setup.py

Sean
