### PR TITLE
Fixed latin1 detector in chardet

### DIFF
--- a/chardet/latin1prober.py
+++ b/chardet/latin1prober.py
@@ -130,10 +130,10 @@ class Latin1Prober(CharSetProber):
         if total < 0.01:
             confidence = 0.0
         else:
-            confidence = (self._mFreqCounter[3] / total) - (self._mFreqCounter[1] * 20.0 / total)
+            confidence = (self._mFreqCounter[3] - self._mFreqCounter[1] * 20.0) / total
         if confidence < 0.0:
             confidence = 0.0
         # lower the confidence of latin1 so that other more accurate detector
         # can take priority.
-        confidence = confidence * 0.5
+        confidence = confidence * 0.73
         return confidence


### PR DESCRIPTION
Hi David,

Following up on our exchange from a few weeks ago. I've commited the bug fix for the integer math bug (causes a file with even one "low confidence" character to have 0 confidence level) and also updated the confidence multiplier for latin 1 to one that works better (the original multiplier causes many files to be incorrectly detected as iso-latin-2). Testing on both the problem case mentioned ( http://www.lvo.com/GASTRONOMIE/VINS/VITI/VITI1F.HTML ) and the character set tables from http://www.columbia.edu/kermit/csettables.html suggests that the fixed code performs better.

Hope this is useful - it's certainly helped fix a few problem documents in the application I'm working on.

Best,

Doug
